### PR TITLE
GitHub community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -50,6 +50,7 @@ body:
       label: Relevant log output
       description: If you have any relevant logging info, please put it here.
       placeholder: Logs
+      value: "Logs"
       render: shell
   - type: textarea
     id: reproduce

--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -48,7 +48,8 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      description: If you have any relevant logging info, please put it here.
+      placeholder: Logs
       render: shell
   - type: textarea
     id: reproduce

--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -1,0 +1,87 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+projects: ["aranya-project/1"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+        If you need to report a security bug, please report it at securityreports@spideroak.com rather than creating an issue.
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Aranya Software Version
+      description: What version of Aranya were you running?
+      placeholder: Aranya Software Version
+      value: "Aranya Software Version"
+    validations:
+      required: true
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware?
+      description: What hardware are you seeing this issue on?
+      placeholder: Hardware Info
+      value: "Hardware Info"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduce?
+      description: What are the steps to reproduce the issue?
+      placeholder: How To Reproduce the issue
+      value: "How To Reproduce the issue"
+    validations:
+      required: true
+  - type: textarea
+    id: suggestions
+    attributes:
+      label: Suggestions?
+      description: Do you have any suggestions for how to resolve this issue?
+      placeholder: Suggestions
+      value: "Suggestions"
+    validations:
+      required: false
+  - type: input
+    id: name
+    attributes:
+      label: Name?
+      description: Your name if you'd like to be credited for reporting this bug
+      placeholder: Your Name
+      value: "Your Name"
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/aranya-project/.github/CODE_OF_CONDUCT.md). 
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Aranya Community Support
+    url: https://github.com/orgs/aranya-project/discussions
+    about: Please ask and answer questions here.
+  - name: Aranya Security Reporting
+    url: securityreports@spideroak.com
+    about: Please report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/feature_template.yml
+++ b/.github/ISSUE_TEMPLATE/feature_template.yml
@@ -1,0 +1,63 @@
+name: Feature Request
+description: Submit a feature request.
+title: "[Feature]: "
+labels: ["feature", "triage"]
+projects: ["aranya-project/1"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+        If you need to report a security bug, please report it at securityreports@spideroak.com rather than creating an issue.
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature Description
+      description: Please describe the feature you would like to see implemented
+      placeholder: Feature Description
+      value: "Feature Description"
+    validations:
+      required: true
+  - type: textarea
+    id: importance
+    attributes:
+      label: Feature Importance
+      description: Please describe why this feature is important
+      placeholder: Feature Importance
+      value: "Feature Importance"
+    validations:
+      required: true
+  - type: textarea
+    id: suggestions
+    attributes:
+      label: Suggestions?
+      description: Do you have any suggestions for how to implement this feature?
+      placeholder: Suggestions
+      value: "Suggestions"
+    validations:
+      required: false
+  - type: input
+    id: name
+    attributes:
+      label: Name?
+      description: Your name if you'd like to be credited for requesting this feature
+      placeholder: Your Name
+      value: "Your Name"
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/aranya-project/.github/CODE_OF_CONDUCT.md). 
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,48 @@
+# Pull Request Template
+
+## Title
+[Provide a succinct and descriptive title for the pull request, e.g., "Improve caching mechanism for API calls"]
+
+## Type of Change
+- [ ] New feature
+- [ ] Bug fix
+- [ ] Documentation update
+- [ ] CICD
+- [ ] Refactoring
+- [ ] Hotfix
+- [ ] Security patch
+
+## Subsystems Impacted
+- [ ] Rust API
+- [ ] C API
+- [ ] User Library
+- [ ] Aranya Fast Channels
+- [ ] Network Transport
+- [ ] Daemon API
+- [ ] Daemon Config
+- [ ] Daemon Syncer
+- [ ] Daemon Policy
+- [ ] Policy VM
+- [ ] Sync Protocol
+- [ ] Crypto
+
+## Description
+[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]
+
+## Testing
+[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]
+
+## Impact
+[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]
+
+## Additional Information
+[Any additional information that reviewers should be aware of.]
+
+## Checklist
+- [ ] My code adheres to the formatting, coding, and style guidelines of the project.
+- [ ] My code compiles and passes all unit and integration tests on my development machine.
+- [ ] I have performed a self-review of my own code.
+- [ ] I have commented and documented my code, particularly in hard-to-understand areas.
+- [ ] I have updated any relevant documentation and specifications impacted by this change.
+- [ ] My changes generate no new warnings or errors.
+- [ ] My changes did not break any features that were previously working.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-* @elagergren @gknopf @jdygert @ycarmy
-CONTRIBUTING.md @gknopf @ycarmy
+* @elagergren-spideroak @gknopf-aranya @jdygert-spok @ycarmy
+CONTRIBUTING.md @gknopf-aranya @ycarmy
 SECURITY.md @sericso @ycarmy

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+* @elagergren @gknopf @jdygert @ycarmy
+CONTRIBUTING.md @gknopf @ycarmy
+SECURITY.md @sericso @ycarmy

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,25 @@
+# SpiderOak Code of Conduct
+
+## Conduct
+1. We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
+2. Please avoid using overtly sexual aliases or other nicknames that might detract from a friendly, safe and welcoming environment for all.
+3. Please be kind and courteous. There’s no need to be mean or rude.
+4. Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
+5. Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
+6. We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term “harassment” as including the definition here:  [Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md); if you have any lack of clarity about what might be included in that concept, please read their definition. 
+7. Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact us immediately. 
+8. Whether you’re a regular contributor or a newcomer, we care about making this community a safe place for you and we’ve got your back.
+9. Likewise, any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
+
+## Moderation
+These are the policies for upholding our community’s standards of conduct.
+1. Remarks that violate the SpiderOak standards of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
+2. Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not allowed.
+3. Moderators will first respond to such remarks with a warning.
+4. If the warning is unheeded, the user will be “kicked,” i.e., kicked out of the communication channel to cool off.
+5. If the user comes back and continues to make trouble, they will be banned, i.e., indefinitely excluded.
+6. Moderators may choose at their discretion to un-ban the user if it was a first offense and they offer the offended party a genuine apology.
+7. If a moderator bans someone and you think it was unjustified, please take it up with that moderator, or with a different moderator, in private. Complaints about bans in-channel are not allowed.
+8. Moderators are held to a higher standard than other community members. If a moderator creates an inappropriate situation, they should expect less leeway than others.
+
+Adopted from the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,9 @@ Install `cargo make`:
 Keep your toolchain updated by periodically running:
 `rustup update`
 
+The Minimum Supported Rust Version (MSRV) can be found by opening a repository's top-level `Cargo.toml` file and looking for the following line:
+`rust-version = "<Rust version>"`
+
 Install your favorite IDE to edit the source code.
 
 If using VSCode, we recommend these settings to automatically format and lint saved files:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,6 @@ Before contributing, we recommend that you spend some time getting familiar with
 
 Aranya is primarily written in Rust. For useful references on learning Rust, see the [Resources](#resources) section.
 
-## Our Roadmap
-
-Coming soon.
-
-The development roadmap will be a way for SpiderOak to share planned future changes with the development community.
-
 ## Project Management
 
 SpiderOak uses an Agile development process to develop Aranya.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ The development roadmap will be a way for SpiderOak to share planned future chan
 
 ## Project Management
 
-SpiderOak uses an Agile development process to develope Aranya.
+SpiderOak uses an Agile development process to develop Aranya.
 
 This GitHub project contains a SCRUM board that plans effort in 2-week sprints:
 https://github.com/orgs/aranya-project/projects/1
@@ -195,7 +195,7 @@ A PR can typically be marked as "Ready For Review" when it meets the following c
 - Code is compiling.
 - Lints have been resolved.
 - CICD tests are passing.
-- Intended functionality as been implemented.
+- Intended functionality has been implemented.
 - Relevant unit and/or integration tests have been added.
 - Relevant documentation has been updated.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,253 @@
+# How To Contribute To Aranya
+
+Thank you for your interest in contributing to Aranya!
+
+SpiderOak is looking forward to contributions from the open-source community.
+
+## Project Documentation
+
+Before contributing, we recommend that you spend some time getting familiar with the Aranya project documentation:
+[README.md](README.md)
+[overview.md](docs/overview.md)
+[walkthrough.md](docs/walkthrough.md)
+
+Aranya is primarily written in Rust.
+We recommend that contributors learn Rust first:
+- Overview: https://www.rust-lang.org/learn
+- "The Book": https://doc.rust-lang.org/book/
+- Standard Library API: https://doc.rust-lang.org/std/index.html
+- Rust by Example: https://doc.rust-lang.org/stable/rust-by-example/
+- Playground (test and share snippets): https://play.rust-lang.org/
+- Async: https://rust-lang.github.io/async-book/
+- Useful third-party libraries: https://blessed.rs
+
+## Our Roadmap
+
+Coming soon.
+
+The development roadmap will be a way for SpiderOak to share planned future changes with the development community.
+
+## Project Management
+
+SpiderOak uses an Agile development process to develope Aranya.
+
+This GitHub project contains a SCRUM board that plans effort in 2-week sprints:
+https://github.com/orgs/aranya-project/projects/1
+
+## Development Environment Setup
+
+Install Rust:
+https://www.rust-lang.org/tools/install
+
+Install `cargo make`:
+`cargo install cargo-make`
+
+Keep your toolchain updated by periodically running:
+`rustup update`
+
+Install your favorite IDE to edit the source code.
+
+If using VSCode, we recommend these settings to automatically format and lint saved files:
+```
+// Automatically format when saving, for all languages
+"editor.formatOnSave": true,
+// Or just format for Rust.
+"[rust]": { "editor.formatOnSave": true },
+
+// Use nightly rustfmt so we can use unstable config options.
+"rust-analyzer.rustfmt.extraArgs": ["+nightly"],
+
+// Enable clippy linter for extra warnings in-editor
+"rust-analyzer.check.command": "clippy",
+```
+
+## How To Report A Security Bug
+
+Refer to [SECURITY.md](SECURITY.md) for reporting security bugs.
+
+## How To Report A Bug
+
+Create a new issue here for the bug:
+https://github.com/aranya-project/aranya/issues
+
+More information on creating GitHub issues can be found here:
+[Creating A GitHub Issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue)
+
+Add the `bug` label to the issue.
+
+The team will now be able to view and respond to the bug report.
+
+## How To Request A Feature
+
+To share an idea for a new feature, create a discussion here:
+https://github.com/orgs/aranya-project/discussions/categories/ideas
+
+Once the development community has shown interest in the idea, it's time to create an issue.
+
+Create a new issue here for the feature request:
+https://github.com/aranya-project/aranya/issues
+
+More information on creating GitHub issues can be found here:
+[Creating A GitHub Issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue)
+
+Add any relevant labels to the issue.
+
+If you're planning to open a pull request for the feature, assign yourself to the issue.
+
+## How To Submit Changes
+
+First, clone the repository:
+`git clone https://github.com/aranya-project/aranya`
+or
+`git clone git@github.com:aranya-project/aranya.git`
+
+Create a new branch for your changes:
+`git checkout -b <branch>`
+
+You can alternatively create a development branch directly from an existing issue:
+[Creating branch from existing issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-a-branch-for-an-issue)
+
+Make some changes using your favorite IDE.
+
+Before pushing commits, you can run a few commands to see if the changes are good before running them on the CICD pipeline:
+```
+cargo make fmt
+cargo make build
+cargo make unit-tests
+cargo make correctness
+```
+
+Commit the changes to the branch:
+```
+git add .
+git commit -m "commit message"
+git push
+```
+
+Note: when pushing commits for the first time, you may need:
+`git push --set-upstream origin <branch>`
+
+Open a pull request here for your branch:
+https://github.com/aranya-project/aranya/pulls
+
+More information on opening pull requests can be found here:
+[Pull Requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
+
+Request code review from relevant code owners [CODEOWNERS.md](CODEOWNERS.md).
+
+More information on code owners can be found here:
+[Code Owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
+
+The following criteria are used to determine if a pull request can be merged into the protected `main` branch:
+- Code has been properly formatted (`cargo make fmt`)
+- Lint checks are passing
+- Code can be compiled
+- Unit tests are passing (`cargo make unit-tests`)
+- Integration tests are passing
+- All GitHub Actions CICD (Continous Integration Continous Delivery) jobs have passed.
+- All discussions on the pull request have been addressed and resolved
+- Pull request has been reviewed and approved by relevant code owners on the development team at SpiderOak [CODEOWNERS.md](CODEOWNERS.md).
+
+## Github Issue Creation Guidelines
+
+Create a new issue here for the feature request:
+https://github.com/aranya-project/aranya/issues
+
+More information on creating GitHub issues can be found here:
+[Creating A GitHub Issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue)
+
+Try to fill out as much information as possible when creating an issue:
+- Title
+- Description
+- Assignee(s)
+- Labels
+- Project(s)
+- Milestone (if applicable)
+- Development branch(es)
+- Status (e.g. backlog)
+- Story point estimate
+- Links to other relevant issues, discussions, or documentation
+
+Here are some suggestions for how to write good user stories in issue descriptions:
+https://www.easyagile.com/blog/how-to-write-good-user-stories-in-agile-software-development/
+
+Here are some guidelines for adding story point estimates to issues:
+| Story Point Estimate | Amount of Effort Required | Estimated Time Needed                    | Example scenarios                          |
+| -------------------- | ------------------------- | ---------------------------------------- | ------------------------------------------ |
+| 0                    | Tiny                      | Minutes to hours                         | Task in review or typos to fix             |
+| 1                    | Minimum effort            | A day or less                            | Small bug or fixes from review comments    |
+| 2                    | Slight effort             | 2-3 days                                 | Bug fix, cleanup, test                     |
+| 3                    | Mild effort               | A week or less                           | Small feature                              |
+| 5                    | Moderate effort           | A sprint or less                         | Regular feature                            |
+| 8                    | High effort               | More than a sprint. A few weeks.         | Implementing features of a multi-part spec |
+| 13                   | Maximum effort            | Too high to know. Requires more research | Design and implementation of a new feature |
+
+## Pull Request Review Guidelines
+
+Please keep pull request reviews professional and informative.
+
+We encourage developers to open draft PRs early in the development cycle.
+This allows other developers to be aware of changes and start providing feedback.
+Once a PR is ready for more formal review, it can be marked as "Ready For Review".
+
+A PR can typically be marked as "Ready For Review" when it meets the following criteria:
+- Code is formatted.
+- Code is compiling.
+- Lints have been resolved.
+- CICD tests are passing.
+- Intended functionality as been implemented.
+- Relevant unit and/or integration tests have been added.
+- Relevant documentation has been updated.
+
+The purpose of reviewing PRs is to:
+- Improve code quality (functionality, maintainability, readability, thread-safety, etc.).
+- Catch potential security bugs before they are introduced.
+- Allow developers with knowledge of various parts of the project or various domain knowledge to provide feedback.
+- Verify that CICD tests/builds are passing.
+- Ensure that the implementation aligns with the intended vision for the issue.
+- Distribute knowledge of various system components across the team.
+- Determine whether a specification needs to be written before merging the implementation.
+- Ensure that coding standards are followed.
+- Encourage more documentation where needed.
+- Evaluate architectural properties (performance, scalability, reliability, modularity, etc.).
+
+We differentiate between various types of feedback:
+- Requesting a change (must be changed before approving a PR).
+- Comments. Suggestions for improving the PR.
+- Nitpick. A minor issue or preference. Will not prevent a PR from being merged. Nitpick comments are prefaced with a "nit:".
+
+In general, reviewers are assigned to a PR based on the following criteria:
+- Relevant domain/language knowledge.
+- Past experience working on similar issues.
+- Past experience working on a particular part of the codebase.
+- Interest in working on or learning about a particular part of the codebase.
+- It is not practical for every team member to review every PR. And too many reviewers could cause the review cycle to take too much time. Generally, 1 primary reviewer and 1 other person to check for obvious errors or funny business is recommended. Feel free to read PRs you are not assigned as a reviewer on and comment with questions/feedback.
+
+## Testing
+
+To run the unit tests:
+`cargo make unit-tests`
+
+Note: if unit tests are not passing, a pull request cannot be merged.
+
+## Code Of Conduct
+
+Here's a link to our code of conduct:
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+
+## Style Guide And Coding Conventions
+
+We use `rustfmt` to automatically format code:
+https://github.com/rust-lang/rustfmt
+
+Run this command to format code before pushing code to a development branch:
+`cargo make fmt`
+
+## Asking For Help
+
+Our development team would be happy to assist with any questions you may have.
+
+Please open a Q&A discussion for any general questions:
+https://github.com/orgs/aranya-project/discussions/categories/q-a
+
+You can also ask for help in a PR comment or in a discussion on the associated GitHub issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,15 +11,7 @@ Before contributing, we recommend that you spend some time getting familiar with
 [overview.md](docs/overview.md)
 [walkthrough.md](docs/walkthrough.md)
 
-Aranya is primarily written in Rust.
-We recommend that contributors learn Rust first:
-- Overview: https://www.rust-lang.org/learn
-- "The Book": https://doc.rust-lang.org/book/
-- Standard Library API: https://doc.rust-lang.org/std/index.html
-- Rust by Example: https://doc.rust-lang.org/stable/rust-by-example/
-- Playground (test and share snippets): https://play.rust-lang.org/
-- Async: https://rust-lang.github.io/async-book/
-- Useful third-party libraries: https://blessed.rs
+Aranya is primarily written in Rust. For useful references on learning Rust, see the [Resources](#resources) section.
 
 ## Our Roadmap
 
@@ -73,7 +65,8 @@ https://github.com/aranya-project/aranya/issues
 More information on creating GitHub issues can be found here:
 [Creating A GitHub Issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue)
 
-Add the `bug` label to the issue.
+A bug reporting template has been created to make it easier to submit bug reports:
+[Bug template](.github/ISSUE_TEMPLATE/bug_template.yml)
 
 The team will now be able to view and respond to the bug report.
 
@@ -90,7 +83,8 @@ https://github.com/aranya-project/aranya/issues
 More information on creating GitHub issues can be found here:
 [Creating A GitHub Issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue)
 
-Add any relevant labels to the issue.
+A feature request template has been created to make it easier to request new features:
+[Feature request template](.github/ISSUE_TEMPLATE/feature_template.yml)
 
 If you're planning to open a pull request for the feature, assign yourself to the issue.
 
@@ -133,95 +127,13 @@ https://github.com/aranya-project/aranya/pulls
 More information on opening pull requests can be found here:
 [Pull Requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
 
+A pull request template has been created to make it easier to open new pull requests:
+[Pull request template](.github/PULL_REQUEST_TEMPLATE/pull_request_template.yml)
+
 Request code review from relevant code owners [CODEOWNERS.md](CODEOWNERS.md).
 
 More information on code owners can be found here:
 [Code Owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
-
-The following criteria are used to determine if a pull request can be merged into the protected `main` branch:
-- Code has been properly formatted (`cargo make fmt`)
-- Lint checks are passing
-- Code can be compiled
-- Unit tests are passing (`cargo make unit-tests`)
-- Integration tests are passing
-- All GitHub Actions CICD (Continous Integration Continous Delivery) jobs have passed.
-- All discussions on the pull request have been addressed and resolved
-- Pull request has been reviewed and approved by relevant code owners on the development team at SpiderOak [CODEOWNERS.md](CODEOWNERS.md).
-
-## Github Issue Creation Guidelines
-
-Create a new issue here for the feature request:
-https://github.com/aranya-project/aranya/issues
-
-More information on creating GitHub issues can be found here:
-[Creating A GitHub Issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue)
-
-Try to fill out as much information as possible when creating an issue:
-- Title
-- Description
-- Assignee(s)
-- Labels
-- Project(s)
-- Milestone (if applicable)
-- Development branch(es)
-- Status (e.g. backlog)
-- Story point estimate
-- Links to other relevant issues, discussions, or documentation
-
-Here are some suggestions for how to write good user stories in issue descriptions:
-https://www.easyagile.com/blog/how-to-write-good-user-stories-in-agile-software-development/
-
-Here are some guidelines for adding story point estimates to issues:
-| Story Point Estimate | Amount of Effort Required | Estimated Time Needed                    | Example scenarios                          |
-| -------------------- | ------------------------- | ---------------------------------------- | ------------------------------------------ |
-| 0                    | Tiny                      | Minutes to hours                         | Task in review or typos to fix             |
-| 1                    | Minimum effort            | A day or less                            | Small bug or fixes from review comments    |
-| 2                    | Slight effort             | 2-3 days                                 | Bug fix, cleanup, test                     |
-| 3                    | Mild effort               | A week or less                           | Small feature                              |
-| 5                    | Moderate effort           | A sprint or less                         | Regular feature                            |
-| 8                    | High effort               | More than a sprint. A few weeks.         | Implementing features of a multi-part spec |
-| 13                   | Maximum effort            | Too high to know. Requires more research | Design and implementation of a new feature |
-
-## Pull Request Review Guidelines
-
-Please keep pull request reviews professional and informative.
-
-We encourage developers to open draft PRs early in the development cycle.
-This allows other developers to be aware of changes and start providing feedback.
-Once a PR is ready for more formal review, it can be marked as "Ready For Review".
-
-A PR can typically be marked as "Ready For Review" when it meets the following criteria:
-- Code is formatted.
-- Code is compiling.
-- Lints have been resolved.
-- CICD tests are passing.
-- Intended functionality has been implemented.
-- Relevant unit and/or integration tests have been added.
-- Relevant documentation has been updated.
-
-The purpose of reviewing PRs is to:
-- Improve code quality (functionality, maintainability, readability, thread-safety, etc.).
-- Catch potential security bugs before they are introduced.
-- Allow developers with knowledge of various parts of the project or various domain knowledge to provide feedback.
-- Verify that CICD tests/builds are passing.
-- Ensure that the implementation aligns with the intended vision for the issue.
-- Distribute knowledge of various system components across the team.
-- Determine whether a specification needs to be written before merging the implementation.
-- Ensure that coding standards are followed.
-- Encourage more documentation where needed.
-- Evaluate architectural properties (performance, scalability, reliability, modularity, etc.).
-
-We differentiate between various types of feedback:
-- Requesting a change (must be changed before approving a PR).
-- Comments. Suggestions for improving the PR.
-- Nitpick. A minor issue or preference. Will not prevent a PR from being merged. Nitpick comments are prefaced with a "nit:".
-
-In general, reviewers are assigned to a PR based on the following criteria:
-- Relevant domain/language knowledge.
-- Past experience working on similar issues.
-- Past experience working on a particular part of the codebase.
-- Interest in working on or learning about a particular part of the codebase.
-- It is not practical for every team member to review every PR. And too many reviewers could cause the review cycle to take too much time. Generally, 1 primary reviewer and 1 other person to check for obvious errors or funny business is recommended. Feel free to read PRs you are not assigned as a reviewer on and comment with questions/feedback.
 
 ## Testing
 
@@ -251,3 +163,14 @@ Please open a Q&A discussion for any general questions:
 https://github.com/orgs/aranya-project/discussions/categories/q-a
 
 You can also ask for help in a PR comment or in a discussion on the associated GitHub issue.
+
+## Resources
+
+Rust Resources:
+- Overview: https://www.rust-lang.org/learn
+- "The Book": https://doc.rust-lang.org/book/
+- Standard Library API: https://doc.rust-lang.org/std/index.html
+- Rust by Example: https://doc.rust-lang.org/stable/rust-by-example/
+- Playground (test and share snippets): https://play.rust-lang.org/
+- Async: https://rust-lang.github.io/async-book/
+- Useful third-party libraries: https://blessed.rs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,16 +87,7 @@ If you're planning to open a pull request for the feature, assign yourself to th
 
 ## How To Submit Changes
 
-First, clone the repository:
-`git clone https://github.com/aranya-project/aranya`
-or
-`git clone git@github.com:aranya-project/aranya.git`
-
-Create a new branch for your changes:
-`git checkout -b <branch>`
-
-You can alternatively create a development branch directly from an existing issue:
-[Creating branch from existing issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-a-branch-for-an-issue)
+First, fork the repository and clone your fork.
 
 Make some changes using your favorite IDE.
 
@@ -108,15 +99,7 @@ cargo make unit-tests
 cargo make correctness
 ```
 
-Commit the changes to the branch:
-```
-git add .
-git commit -m "commit message"
-git push
-```
-
-Note: when pushing commits for the first time, you may need:
-`git push --set-upstream origin <branch>`
+Commit the changes and push them to the fork.
 
 Open a pull request here for your branch:
 https://github.com/aranya-project/aranya/pulls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ Here's a link to our code of conduct:
 
 ## Style Guide And Coding Conventions
 
-We use `rustfmt` to automatically format code:
+We use nightly `rustfmt` to automatically format code:
 https://github.com/rust-lang/rustfmt
 
 Run this command to format code before pushing code to a development branch:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy for the Aranya Project
+
+## Reporting a Security Vulnerability
+
+The Aranya team takes security seriously. We appreciate your efforts to responsibly disclose your findings and will make every effort to acknowledge your contributions.
+
+Discovered issues can be communicated privately to our security team at: <securityreports@spideroak.com>. 
+
+Please do not report security vulnerabilities through public GitHub issues. We also appreciate being provided with a reasonable amount of time to resolve the issue before any disclosure to the public or a third party. We may disclose the issue before resolution, if appropriate.
+
+Please include the following information in your report if applicable:
+
+- Description of the vulnerability
+- Aranya software version, hardware platform and OS version
+- Logs and artifacts
+- Steps to reproduce the issue
+- Potential impact of the vulnerability
+- Suggested mitigation or fix (if any)
+- Your name/handle (if you wish to be credited)
+
+## Supported Versions
+
+The latest version or release is supported.
+
+## Disclosure Policy
+
+When we receive a security bug report, we will assign it to a primary handler. This person will coordinate the fix and release process, involving the following steps:
+
+1. Confirm the problem and determine the affected versions.
+2. Audit code to find any potential similar problems.
+3. Prepare fixes for all still-supported releases.
+4. Release new security fix versions and update the public repository.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved, please submit a pull request or open an issue in our public repository.
+
+Last Updated: 10OCT2024


### PR DESCRIPTION
Adds a default `CONTRIBUTING.md` for the Aranya project.
Creates issue and PR templates to facilitate open-source contributions.

Copies over default `SECURITY.md` and `CODE_OF_CONDUCT.md` from `aranya` and `aranya-core` repos.
`SECURITY.md` and `CODE_OF_CONDUCT.md` can be removed from the other repos once this PR is merged.

We can add a top-level project `README.md` to the `.github` repo on another PR.

Reference:
https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file